### PR TITLE
Add requirements to run examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # local
 
 *~
+examples/*.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 cloudpathlib >= 0.10
 icecream >= 2.1
-rdflib >= 6.2
+networkx>=2.8.7
 pandas >= 1.4
 pydantic >= 1.10
 pyarrow >= 6.0
+rdflib >= 6.2
 typer[all] >= 0.6


### PR DESCRIPTION
Additional libraries may be needed to run the examples. They can be listed in `requirements-examples.txt`